### PR TITLE
Fix Dart client URL

### DIFF
--- a/wiki/content/clients/index.md
+++ b/wiki/content/clients/index.md
@@ -483,7 +483,7 @@ These third-party clients are contributed by the community and are not officiall
 
 ### Dart
 
-- https://github.com/katutz/dgraph
+- https://github.com/marceloneppel/dgraph
 
 ### Elixir
 


### PR DESCRIPTION
I fixed the Dart client URL to the new one. Now the client is compatible with Dgraph 1.1.x.